### PR TITLE
Make forcing capping independent of useCTRL and ctrlUseGen

### DIFF
--- a/v05/1deg/code_v4r5/exf_getffields.F
+++ b/v05/1deg/code_v4r5/exf_getffields.F
@@ -780,7 +780,26 @@ cdm #endif
        ENDDO
        ENDDO
 
+#ifdef ALLOW_ROTATE_UV_CONTROLS
+       CALL ROTATE_UV2EN_RL(tmpUX,tmpVY,tmpUE,tmpVN,
+     &      .FALSE.,.FALSE.,.TRUE.,1,myThid)
+
        DO bj = myByLo(myThid),myByHi(myThid)
+         DO bi = myBxLo(myThid),myBxHi(myThid)
+          DO j = 1,sNy
+           DO i = 1,sNx
+             uwind(i,j,bi,bj)=uwind(i,j,bi,bj)+tmpUX(i,j,bi,bj)
+             vwind(i,j,bi,bj)=vwind(i,j,bi,bj)+tmpVY(i,j,bi,bj)
+           ENDDO
+          ENDDO
+         ENDDO
+       ENDDO
+#endif /* ALLOW_ROTATE_UV_CONTROLS */
+
+      ENDIF !if (ctrlUseGen) then
+#endif
+
+      DO bj = myByLo(myThid),myByHi(myThid)
        DO bi = myBxLo(myThid),myBxHi(myThid)
         DO j = 1,sNy
          DO i = 1,sNx
@@ -810,26 +829,7 @@ cdm #endif
          ENDDO
         ENDDO
        ENDDO
-       ENDDO
-
-#ifdef ALLOW_ROTATE_UV_CONTROLS
-       CALL ROTATE_UV2EN_RL(tmpUX,tmpVY,tmpUE,tmpVN,
-     &      .FALSE.,.FALSE.,.TRUE.,1,myThid)
-
-       DO bj = myByLo(myThid),myByHi(myThid)
-         DO bi = myBxLo(myThid),myBxHi(myThid)
-          DO j = 1,sNy
-           DO i = 1,sNx
-             uwind(i,j,bi,bj)=uwind(i,j,bi,bj)+tmpUX(i,j,bi,bj)
-             vwind(i,j,bi,bj)=vwind(i,j,bi,bj)+tmpVY(i,j,bi,bj)
-           ENDDO
-          ENDDO
-         ENDDO
-       ENDDO
-#endif /* ALLOW_ROTATE_UV_CONTROLS */
-
-      ENDIF !if (ctrlUseGen) then
-#endif
+      ENDDO
 
       RETURN
       END


### PR DESCRIPTION
This commit adjusts the forcing capping logic in v05/1deg/code_v4r5/exf_getffields.F to ensure it operates independently of the `useCTRL` and `ctrlUseGen` boolean variables. Previously, the application of capping was conditioned on these variables, which could lead to scenarios where forcings were not appropriately capped. This change ensures consistent application of capping to maintain forcings within their physical limits regardless of the states of `useCTRL` and `ctrlUseGen`.