### PR TITLE
Update mpi version (mpi-hpe/mpt.2.25 not working any more on Pleiades)

### DIFF
--- a/regions/CCS/v05/code/linux_amd64_ifort+mpi_ice_nas
+++ b/regions/CCS/v05/code/linux_amd64_ifort+mpi_ice_nas
@@ -6,7 +6,7 @@
 # or using older intel compiler:
 #   > module load comp-intel/2016.2.181
 #- and, with MPI:
-#   > module load mpi-hpe/mpt.2.25
+#   > module load mpi-hpe
 #   > module load hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 #- and without:
 #   > module load hdf4/4.2.12 hdf5/1.8.18_serial netcdf/4.4.1.1_serial

--- a/regions/GoA/v05/code/linux_amd64_ifort+mpi_ice_nas
+++ b/regions/GoA/v05/code/linux_amd64_ifort+mpi_ice_nas
@@ -6,7 +6,7 @@
 # or using older intel compiler:
 #   > module load comp-intel/2016.2.181
 #- and, with MPI:
-#   > module load mpi-hpe/mpt.2.25
+#   > module load mpi-hpe
 #   > module load hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 #- and without:
 #   > module load hdf4/4.2.12 hdf5/1.8.18_serial netcdf/4.4.1.1_serial

--- a/regions/LR17/v05/code/linux_amd64_ifort+mpi_ice_nas
+++ b/regions/LR17/v05/code/linux_amd64_ifort+mpi_ice_nas
@@ -6,7 +6,7 @@
 # or using older intel compiler:
 #   > module load comp-intel/2016.2.181
 #- and, with MPI:
-#   > module load mpi-hpe/mpt.2.25
+#   > module load mpi-hpe
 #   > module load hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 #- and without:
 #   > module load hdf4/4.2.12 hdf5/1.8.18_serial netcdf/4.4.1.1_serial

--- a/regions/Med/v05/code/linux_amd64_ifort+mpi_ice_nas
+++ b/regions/Med/v05/code/linux_amd64_ifort+mpi_ice_nas
@@ -6,7 +6,7 @@
 # or using older intel compiler:
 #   > module load comp-intel/2016.2.181
 #- and, with MPI:
-#   > module load mpi-hpe/mpt.2.25
+#   > module load mpi-hpe
 #   > module load hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 #- and without:
 #   > module load hdf4/4.2.12 hdf5/1.8.18_serial netcdf/4.4.1.1_serial

--- a/regions/RedSea/v05/code/linux_amd64_ifort+mpi_ice_nas
+++ b/regions/RedSea/v05/code/linux_amd64_ifort+mpi_ice_nas
@@ -6,7 +6,7 @@
 # or using older intel compiler:
 #   > module load comp-intel/2016.2.181
 #- and, with MPI:
-#   > module load mpi-hpe/mpt.2.25
+#   > module load mpi-hpe
 #   > module load hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 #- and without:
 #   > module load hdf4/4.2.12 hdf5/1.8.18_serial netcdf/4.4.1.1_serial

--- a/v02/cs510_Brix/readme.txt
+++ b/v02/cs510_Brix/readme.txt
@@ -12,7 +12,7 @@ cd ..
 mkdir build
 cd build
 module purge
-module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
+module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 ../tools/genmake2 -of \
     ../../ecco_darwin/v02/cs510_brix/code/linux_amd64_ifort+mpi_ice_nas \
     -mo ../../ecco_darwin/v02/cs510_brix/code

--- a/v03/cs510_Brix/readme.txt
+++ b/v03/cs510_Brix/readme.txt
@@ -17,7 +17,7 @@ cd ..
 mkdir build
 cd build
 module purge
-module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
+module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 ../tools/genmake2 -of \
     ../../ecco_darwin/v03/cs510_brix/code/linux_amd64_ifort+mpi_ice_nas \
     -mo ../../ecco_darwin/v03/cs510_brix/code

--- a/v03/cs510_latest/readme.txt
+++ b/v03/cs510_latest/readme.txt
@@ -9,7 +9,7 @@ cd ..
 mkdir build
 cd build
 module purge
-module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
+module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 ../tools/genmake2 -of ../tools/build_options/linux_amd64_ifort+mpi_ice_nas \
     -mo ../../ecco_darwin/v03/cs510_latest/code
 make depend

--- a/v04/llc270_JAMES_budget/readme_darwin.txt
+++ b/v04/llc270_JAMES_budget/readme_darwin.txt
@@ -15,7 +15,7 @@
  mkdir build run
  cd build
  module purge
- module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
+ module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
  ../tools/genmake2 -of \
   ../../ecco_darwin/v04/llc270_JAMES_budget/code/linux_amd64_ifort+mpi_ice_nas -mo \
   '../../ecco_darwin/v04/llc270_JAMES_budget/code_darwin ../../ecco_darwin/v04/llc270_JAMES_budget/code'

--- a/v04/llc270_JAMES_paper/readme/readme_85_92.txt
+++ b/v04/llc270_JAMES_paper/readme/readme_85_92.txt
@@ -14,7 +14,7 @@
  mkdir build run
  cd build
  module purge
- module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
+ module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
  MOD="../../ecco_darwin/v04/llc270_JAMES_paper"
  ../tools/genmake2 -of ${MOD}/code/linux_amd64_ifort+mpi_ice_nas \
                    -mo "${MOD}/code ${MOD}/code_85_92 "

--- a/v04/llc270_JAMES_paper/readme/readme_ecco_darwin.txt
+++ b/v04/llc270_JAMES_paper/readme/readme_ecco_darwin.txt
@@ -21,7 +21,7 @@
  mkdir build run
  cd build
  module purge
- module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
+ module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
  ../tools/genmake2 -of \
   ../../ecco_darwin/v04/llc270_JAMES_paper/code/linux_amd64_ifort+mpi_ice_nas -mo \
   '../../ecco_darwin/v04/llc270_JAMES_paper/code_darwin ../../ecco_darwin/v04/llc270_JAMES_paper/code'

--- a/v04/llc270_JAMES_paper/readme/readme_ecco_darwin_verification.txt
+++ b/v04/llc270_JAMES_paper/readme/readme_ecco_darwin_verification.txt
@@ -15,7 +15,7 @@
  mkdir build run
  cd build
  module purge
- module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
+ module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
  ../tools/genmake2 -ieee -of \
   ../../ecco_darwin/v04/llc270_JAMES_paper/code/linux_amd64_ifort+mpi_ice_nas -mo \
   '../../ecco_darwin/v04/llc270_JAMES_paper/code_darwin ../../ecco_darwin/v04/llc270_JAMES_paper/code'

--- a/v04/llc270_JAMES_paper/readme/readme_physics.txt
+++ b/v04/llc270_JAMES_paper/readme/readme_physics.txt
@@ -12,7 +12,7 @@
  mkdir build run
  cd build
  module purge
- module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
+ module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
  MOD="../../ecco_darwin/v04/llc270_JAMES_paper"
  ../tools/genmake2 -of ${MOD}/code/linux_amd64_ifort+mpi_ice_nas \
                    -mo ${MOD}/code

--- a/v04/llc270_devel/readme_darwin.txt
+++ b/v04/llc270_devel/readme_darwin.txt
@@ -16,7 +16,7 @@ cd ..
 mkdir build
 cd build
 module purge
-module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
+module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 ../tools/genmake2 -of \
   ../../ecco_darwin/v04/llc270_devel/code/linux_amd64_ifort+mpi_ice_nas -mo \
   '../../ecco_darwin/v04/llc270_devel/code_darwin ../../ecco_darwin/v04/llc270_devel/code'

--- a/v05/1deg/input_darwin_v4r4/job_ECCOV4r4
+++ b/v05/1deg/input_darwin_v4r4/job_ECCOV4r4
@@ -16,7 +16,7 @@
 #PBS -e error
 
 module purge
-module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
+module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 module list
 
 umask 022

--- a/v05/1deg/readme_darwin_v4r4.txt
+++ b/v05/1deg/readme_darwin_v4r4.txt
@@ -15,7 +15,7 @@ cd darwin3
 mkdir build run
 cd build
 rm *
-module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
+module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 MOD="../../ecco_darwin/v05/1deg"
 ../tools/genmake2 -of ../tools/build_options/linux_amd64_ifort+mpi_ice_nas \
 	-mo '../../ecco_darwin/v05/1deg/code_darwin_v4r4 ../../ecco_darwin/v05/1deg/code_v4r4' -mpi

--- a/v05/1deg/readme_darwin_v4r5.txt
+++ b/v05/1deg/readme_darwin_v4r5.txt
@@ -25,7 +25,7 @@ cd darwin3
 mkdir build run
 cd build
 rm *
-module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt python3/3.9.12
+module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt python3/3.9.12
 MOD="../../ecco_darwin/v05/1deg"
 ../tools/genmake2 -of ../tools/build_options/linux_amd64_ifort+mpi_ice_nas \
 	-mo '../../ecco_darwin/v05/1deg/code_darwin_v4r5 ../../ecco_darwin/v05/1deg/code_v4r5' -mpi

--- a/v05/1deg/readme_v4r4.txt
+++ b/v05/1deg/readme_v4r4.txt
@@ -15,7 +15,7 @@ cd darwin3
 mkdir build run
 cd build
 rm *
-module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
+module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 MOD="../../ecco_darwin/v05/1deg"
 ../tools/genmake2 -of ../tools/build_options/linux_amd64_ifort+mpi_ice_nas \
 		  -mo ${MOD}/code_v4r4 -mpi

--- a/v05/1deg/readme_v4r5.txt
+++ b/v05/1deg/readme_v4r5.txt
@@ -25,7 +25,7 @@ cd MITgcm
 mkdir build run
 cd build
 rm *
-module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
+module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 MOD="../../ecco_darwin/v05/1deg"
 ../tools/genmake2 -of ../tools/build_options/linux_amd64_ifort+mpi_ice_nas \
 		  -mo ${MOD}/code_v4r5 -mpi
@@ -61,7 +61,7 @@ cd MITgcm
 mkdir build2 run2
 cd build2
 rm *
-module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
+module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 MOD="../../ecco_darwin/v05/1deg"
 ../tools/genmake2 -of ../tools/build_options/linux_amd64_ifort+mpi_ice_nas \
 		  -mo ${MOD}/code_v4r5_v2 -mpi

--- a/v05/1deg_CDR/readme_darwin.txt
+++ b/v05/1deg_CDR/readme_darwin.txt
@@ -15,7 +15,7 @@ cd darwin3
 mkdir build_cdr run_cdr
 cd build_cdr
 rm *
-module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
+module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 MOD="../../ecco_darwin/v05/1deg"
 ../tools/genmake2 -of ../tools/build_options/linux_amd64_ifort+mpi_ice_nas \
 	-mo '../../ecco_darwin/v05/1deg_CDR/code_darwin ../../ecco_darwin/v05/1deg/code_darwin ../../ecco_darwin/v05/1deg/code_v4r4' -mpi

--- a/v05/1deg_runoff/readme_darwin_v4r5.txt
+++ b/v05/1deg_runoff/readme_darwin_v4r5.txt
@@ -17,7 +17,7 @@ cd darwin3
 mkdir build run
 cd build
 rm *
-module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt python3/3.9.12
+module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt python3/3.9.12
 MOD="../../ecco_darwin/v05/1deg_runoff"
 ../tools/genmake2 -of ../tools/build_options/linux_amd64_ifort+mpi_ice_nas \
 	-mo '../../ecco_darwin/v05/1deg_runoff/code_darwin_v4r5 ../../ecco_darwin/v05/1deg_runoff/code_v4r5' -mpi

--- a/v05/3deg/input/job_3deg_darwin3
+++ b/v05/3deg/input/job_3deg_darwin3
@@ -16,7 +16,7 @@
 #PBS -e error
 
 module purge
-module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
+module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 module list
 
 umask 022

--- a/v05/3deg/readme.txt
+++ b/v05/3deg/readme.txt
@@ -39,7 +39,7 @@
 #    Prerequisite: 1. Get code
  cd ../build
  rm *
- module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
+ module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
  cp ../../ecco_darwin/v05/3deg/code/SIZE.h_mpi SIZE.h
  ../tools/genmake2 -of  ../../ecco_darwin/v05/llc270/code/linux_amd64_ifort+mpi_ice_nas  \
  -mo '../../ecco_darwin/v05/3deg/code ../../ecco_darwin/v05/llc270/code_darwin ../../ecco_darwin/v05/llc270/code' -mpi

--- a/v05/3deg/readme_sed.txt
+++ b/v05/3deg/readme_sed.txt
@@ -40,7 +40,7 @@
 #    Prerequisite: 1. Get code
  cd ../build
  rm *
- module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
+ module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
  cp ../../ecco_darwin/v05/3deg/code/SIZE.h_mpi SIZE.h
  ../tools/genmake2 -of  ../../ecco_darwin/v05/llc270/code/linux_amd64_ifort+mpi_ice_nas  \
  -mo '../../ecco_darwin/v05/3deg/code ../../ecco_darwin/v05/llc270_sediment/code_darwin ../../ecco_darwin/v05/llc270/code' -mpi

--- a/v05/3deg_CDR/input/job_3deg_darwin3
+++ b/v05/3deg_CDR/input/job_3deg_darwin3
@@ -19,7 +19,7 @@
 #PBS -e error
 
 module purge
-module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
+module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 module list
 
 umask 022

--- a/v05/3deg_CDR_MacroA/input/job_3deg_darwin3
+++ b/v05/3deg_CDR_MacroA/input/job_3deg_darwin3
@@ -19,7 +19,7 @@
 #PBS -e error
 
 module purge
-module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
+module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 module list
 
 umask 022

--- a/v05/llc270/code/linux_amd64_ifort+mpi_ice_nas
+++ b/v05/llc270/code/linux_amd64_ifort+mpi_ice_nas
@@ -6,7 +6,7 @@
 # or using older intel compiler:
 #   > module load comp-intel/2016.2.181
 #- and, with MPI:
-#   > module load mpi-hpe/mpt.2.25
+#   > module load mpi-hpe
 #   > module load hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 #- and without:
 #   > module load hdf4/4.2.12 hdf5/1.8.18_serial netcdf/4.4.1.1_serial

--- a/v05/llc270/code/linux_amd64_ifort+mpi_ice_nas_rome
+++ b/v05/llc270/code/linux_amd64_ifort+mpi_ice_nas_rome
@@ -6,7 +6,7 @@
 # or using older intel compiler:
 #   > module load comp-intel/2016.2.181
 #- and, with MPI:
-#   > module load mpi-hpe/mpt.2.25
+#   > module load mpi-hpe
 #   > module load hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 #- and without:
 #   > module load hdf4/4.2.12 hdf5/1.8.18_serial netcdf/4.4.1.1_serial

--- a/v05/llc270_N2O/code/linux_amd64_ifort+mpi_ice_nas
+++ b/v05/llc270_N2O/code/linux_amd64_ifort+mpi_ice_nas
@@ -6,7 +6,7 @@
 # or using older intel compiler:
 #   > module load comp-intel/2016.2.181
 #- and, with MPI:
-#   > module load mpi-hpe/mpt.2.25
+#   > module load mpi-hpe
 #   > module load hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 #- and without:
 #   > module load hdf4/4.2.12 hdf5/1.8.18_serial netcdf/4.4.1.1_serial

--- a/v05/llc270_N2O/code/linux_amd64_ifort+mpi_ice_nas_rome
+++ b/v05/llc270_N2O/code/linux_amd64_ifort+mpi_ice_nas_rome
@@ -6,7 +6,7 @@
 # or using older intel compiler:
 #   > module load comp-intel/2016.2.181
 #- and, with MPI:
-#   > module load mpi-hpe/mpt.2.25
+#   > module load mpi-hpe
 #   > module load hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 #- and without:
 #   > module load hdf4/4.2.12 hdf5/1.8.18_serial netcdf/4.4.1.1_serial

--- a/v05/llc270_sediment/code/linux_amd64_ifort+mpi_ice_nas
+++ b/v05/llc270_sediment/code/linux_amd64_ifort+mpi_ice_nas
@@ -6,7 +6,7 @@
 # or using older intel compiler:
 #   > module load comp-intel/2016.2.181
 #- and, with MPI:
-#   > module load mpi-hpe/mpt.2.25
+#   > module load mpi-hpe
 #   > module load hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 #- and without:
 #   > module load hdf4/4.2.12 hdf5/1.8.18_serial netcdf/4.4.1.1_serial

--- a/v05/llc270_sediment/code/linux_amd64_ifort+mpi_ice_nas_rome
+++ b/v05/llc270_sediment/code/linux_amd64_ifort+mpi_ice_nas_rome
@@ -6,7 +6,7 @@
 # or using older intel compiler:
 #   > module load comp-intel/2016.2.181
 #- and, with MPI:
-#   > module load mpi-hpe/mpt.2.25
+#   > module load mpi-hpe
 #   > module load hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 #- and without:
 #   > module load hdf4/4.2.12 hdf5/1.8.18_serial netcdf/4.4.1.1_serial

--- a/v05/llc270_sediment/input/job_ECCO_darwin
+++ b/v05/llc270_sediment/input/job_ECCO_darwin
@@ -18,7 +18,7 @@
 #PBS -e error
 
 module purge
-module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
+module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 module list
 
 umask 022

--- a/v06/1deg/readme_darwin_v4r5.txt
+++ b/v06/1deg/readme_darwin_v4r5.txt
@@ -17,7 +17,7 @@ cd darwin3
 mkdir build run
 cd build
 rm *
-module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt python3/3.9.12
+module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt python3/3.9.12
 MOD="../../ecco_darwin/v06/1deg"
 ../tools/genmake2 -of ../tools/build_options/linux_amd64_ifort+mpi_ice_nas \
 	-mo '../../ecco_darwin/v06/1deg/code_darwin_v4r5 ../../ecco_darwin/v06/1deg/code_v4r5' -mpi

--- a/v06/llc270/input/job_ECCO_darwin
+++ b/v06/llc270/input/job_ECCO_darwin
@@ -18,7 +18,7 @@
 #PBS -e error
 
 module purge
-module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
+module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
 module list
 
 umask 022

--- a/v06/llc270/readme.txt
+++ b/v06/llc270/readme.txt
@@ -13,7 +13,7 @@ cd build
 # 2. Build executable for v06 ECCO-Darwin
 
 module purge
-module load comp-intel/2020.4.304 mpi-hpe/mpt.2.25 hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt python3/3.9.12
+module load comp-intel/2020.4.304 mpi-hpe hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt python3/3.9.12
 ../tools/genmake2 -of ../../ecco_darwin/v06/llc270/code/linux_amd64_ifort+mpi_ice_nas \
   -mo '../../ecco_darwin/v06/llc270/code_darwin ../../ecco_darwin/v06/llc270/code'
 make depend


### PR DESCRIPTION
Update the mpi-hpe version. The specific version mpi-hpe/mpt.2.25 no longer works on Pleiades; instead, use the default "mpi-hpe", which automatically points to the latest functional version.